### PR TITLE
feat(build): apply repository-conventions plugin for GCP AR maven-remote proxy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id 'io.kestra.gradle.repository-conventions' version '1.2.3'
     id 'io.kestra.gradle.spotless-conventions' version '1.1.0'
     id "com.vanniktech.maven.publish" version "0.36.0"
     id "io.kestra.gradle.inject-bom-versions" version "1.2.2"


### PR DESCRIPTION
## Summary

Apply `io.kestra.gradle.repository-conventions` plugin (kestra-io/gradle-plugin#37) to route Maven dependency resolution through the GCP AR `maven-remote` caching proxy on CI, avoiding Maven Central 429s on shared GitHub Actions runners.

## Behavior

- `MAVEN_REMOTE_TOKEN` set (CI with `GCP_SERVICE_ACCOUNT`): proxy prepended before `mavenCentral()`
- `MAVEN_REMOTE_TOKEN` absent (local dev, forks): no-op, `mavenCentral()` used as usual

## Dependency

Requires kestra-io/gradle-plugin#37 merged and released as `v1.2.3`.